### PR TITLE
Add full CRUD routes for cats

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,18 @@ docker compose up -d
 ```
 
 O projeto iniciará na porta 8080 do localhost. :)
+
+## Rotas
+
+* `GET /cats` - lista todos os gatos
+* `POST /cats` - cria um novo gato
+* `GET /cats/:id` - retorna um gato especifico
+* `PUT /cats/:id` - atualiza um gato
+* `DELETE /cats/:id` - remove um gato
+
+Para rodar os testes:
+
+```bash
+go test ./...
+```
+

--- a/api/resources/cats/cats.router.go
+++ b/api/resources/cats/cats.router.go
@@ -5,8 +5,9 @@ import (
 )
 
 func Router(r *gin.Engine) {
-
 	r.GET("/cats", getCats)
-	// r.POST("/cats", postCats)
-	// r.GET("/cats/:id", getCatByID)
+	r.POST("/cats", postCat)
+	r.GET("/cats/:id", getCatByID)
+	r.PUT("/cats/:id", updateCat)
+	r.DELETE("/cats/:id", deleteCat)
 }

--- a/api/resources/cats/cats.service.go
+++ b/api/resources/cats/cats.service.go
@@ -24,3 +24,62 @@ func getCats(c *gin.Context) {
 	logrus.Info("Fetching all cats")
 	c.IndentedJSON(http.StatusOK, cats)
 }
+
+func postCat(c *gin.Context) {
+	var newCat cat
+
+	if err := c.BindJSON(&newCat); err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	cats = append(cats, newCat)
+	c.IndentedJSON(http.StatusCreated, newCat)
+}
+
+func getCatByID(c *gin.Context) {
+	id := c.Param("id")
+
+	for _, a := range cats {
+		if a.ID == id {
+			c.IndentedJSON(http.StatusOK, a)
+			return
+		}
+	}
+
+	c.Status(http.StatusNotFound)
+}
+
+func updateCat(c *gin.Context) {
+	id := c.Param("id")
+	var newCat cat
+
+	if err := c.BindJSON(&newCat); err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	for i, a := range cats {
+		if a.ID == id {
+			cats[i] = newCat
+			c.IndentedJSON(http.StatusOK, newCat)
+			return
+		}
+	}
+
+	c.Status(http.StatusNotFound)
+}
+
+func deleteCat(c *gin.Context) {
+	id := c.Param("id")
+
+	for i, a := range cats {
+		if a.ID == id {
+			cats = append(cats[:i], cats[i+1:]...)
+			c.Status(http.StatusNoContent)
+			return
+		}
+	}
+
+	c.Status(http.StatusNotFound)
+}

--- a/api/resources/cats/cats.service_test.go
+++ b/api/resources/cats/cats.service_test.go
@@ -1,0 +1,67 @@
+package cats
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setupRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	Router(r)
+	return r
+}
+
+func resetCats() {
+	cats = []cat{
+		{ID: "1", Name: "Whiskers", Breed: "Siamese", Age: 3},
+		{ID: "2", Name: "Tiger", Breed: "Bengal", Age: 7},
+		{ID: "3", Name: "Mittens", Breed: "Tabby", Age: 5},
+	}
+}
+
+func TestCRUD(t *testing.T) {
+	resetCats()
+	router := setupRouter()
+
+	// create
+	newCat := cat{ID: "4", Name: "NewCat", Breed: "Mixed", Age: 1}
+	body, _ := json.Marshal(newCat)
+	req, _ := http.NewRequest(http.MethodPost, "/cats", bytes.NewBuffer(body))
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, resp.Code)
+	}
+
+	// read
+	req, _ = http.NewRequest(http.MethodGet, "/cats/4", nil)
+	resp = httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, resp.Code)
+	}
+
+	// update
+	updated := cat{ID: "4", Name: "Updated", Breed: "Mixed", Age: 2}
+	body, _ = json.Marshal(updated)
+	req, _ = http.NewRequest(http.MethodPut, "/cats/4", bytes.NewBuffer(body))
+	resp = httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, resp.Code)
+	}
+
+	// delete
+	req, _ = http.NewRequest(http.MethodDelete, "/cats/4", nil)
+	resp = httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, resp.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- implement POST/PUT/DELETE functionality
- add router routes and test coverage
- document endpoints and how to run tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687bb375abf08321a5f68219891075a8